### PR TITLE
修复刷Unit1时出现No Such Section刷不了的问题

### DIFF
--- a/Form1.frm
+++ b/Form1.frm
@@ -349,6 +349,7 @@ Dim pStr As String
             End If
         End If
         
+        If UnitID = "" Then UnitID = "1"  '刷Unit1时获取的UnitID为"",导致错误,应改为"1"
         If SectionID = "" Then SectionID = LevelID & UnitID & "11"
         If SubSectionID = "" Then SubSectionID = "0"
         


### PR DESCRIPTION
刷Unit1时获取的UnitID为"",导致错误,应改为"1"
还有个问题,刷的分数会非常高，下面是决定有Num个题目的Section要刷对NumTmp道题的代码https://github.com/ranulldd/NEIE-Assistant/blob/8deb0e7edb4e05527bc7b17cfc2d0fb5d444f878/Form1.frm#L387-L398
设置成80分，一个单元通常会得到99+，因为一个单元有20来个Section，可能只有一两个Section的Num大于10。可以优化下